### PR TITLE
fix the flaky test

### DIFF
--- a/lang/java/avro/src/test/java/org/apache/avro/reflect/TestNonStringMapKeys.java
+++ b/lang/java/avro/src/test/java/org/apache/avro/reflect/TestNonStringMapKeys.java
@@ -89,7 +89,9 @@ public class TestNonStringMapKeys {
     byte[] jsonBytes = testJsonEncoder(testType, entityObj1);
     assertNotNull(jsonBytes, "Unable to serialize using jsonEncoder");
     GenericRecord jsonRecord = testJsonDecoder(testType, jsonBytes, entityObj1);
-    assertEquals(record, jsonRecord, "JSON decoder output not same as Binary Decoder");
+    List<GenericRecord> expectedEmployees = (List<GenericRecord>) record.get("employees");
+    List<GenericRecord> actualEmployees = (List<GenericRecord>) jsonRecord.get("employees");
+    assertTrue(expectedEmployees.containsAll(actualEmployees) && actualEmployees.containsAll(expectedEmployees), "JSON decoder output not same as Binary Decoder");
   }
 
   @Test


### PR DESCRIPTION
This PR addresses a flaky test issue in the TestNonStringMapKeys class. The test was failing intermittently due to order sensitivity in the comparison of employee data within the employees map. JSON objects do not guarantee order, which led to inconsistencies between the expected and actual results during test runs. Run "mvn -pl lang/java/avro \ edu.illinois:nondex-maven-plugin:2.1.7:nondex
-Dtest=org.apache.avro.reflect.TestNonStringMapKeys.testNonStringMapKeys" in this condition and notice that test failure:

'TestNonStringMapKeys.testNonStringMapKeys:95 JSON decoder output not same as Binary Decoder expected:<{"employees": [{"key": {"id": 1}, "value": {"name": "Foo"}}, {"key": {"id": 2}, "value": {"name": "Bar"}}]}> but was:<{"employees": [{"key": {"id": 2}, "value": {"name": "Bar"}}, {"key": {"id": 1}, "value": {"name": "Foo"}}]}>'

The flaky test was caused by the order-sensitive comparison between the expected and actual employees list when decoded using different formats. This issue is observed when running the test on different environments or repeated test executions.

The fix updates the test to compare the contents of the employees lists without considering order. The lists are compared using the containsAll method to ensure that both lists contain the same elements, ignoring the order of elements.

The fix can be verified by running the test suite multiple times to ensure that the order of elements no longer affects the outcome.